### PR TITLE
Fix SQL table definitions by adding missing column types

### DIFF
--- a/create1.sql
+++ b/create1.sql
@@ -69,7 +69,7 @@ CREATE TABLE Product (
     productID PRIMARY KEY
     name TEXT NOT NULL,
     price NUMERIC NOT NULL CHECK (price > 0),
-    productType
+    productType TEXT NOT NULL,
 );
 
 DROP TABLE IF EXISTS Ingredient;
@@ -86,7 +86,9 @@ CREATE TABLE Supplier (
     supplierID PRIMARY KEY NOT NULL UNIQUE CHECK (supplierID > 0),
     supplierName TEXT NOT NULL,
     contactNumber TEXT NOT NULL,
-    ingredient
+    ingredientSupplied INTEGER NOT NULL,
+
+    FOREIGN KEY (ingredientSupplied) REFERENCES Ingredient(ingredientID) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 DROP TABLE IF EXISTS Sale;


### PR DESCRIPTION
This pull request includes changes to the `create1.sql` file to ensure data integrity and improve the database schema. The most important changes include adding constraints to the `Product` and `Supplier` tables and adding a foreign key relationship.

Schema improvements:

* [`create1.sql`](diffhunk://#diff-184ca5fd1c3cd0a167e9a328eb2ea765a5d1c319918b4bf28f2891e507cebb8cL72-R72): Modified the `productType` column in the `Product` table to be `TEXT NOT NULL` to ensure that each product has a specified type.
* [`create1.sql`](diffhunk://#diff-184ca5fd1c3cd0a167e9a328eb2ea765a5d1c319918b4bf28f2891e507cebb8cL89-R91): Renamed the `ingredient` column to `ingredientSupplied` in the `Supplier` table and set it to `INTEGER NOT NULL` to clarify its purpose and enforce that a value must be provided.
* [`create1.sql`](diffhunk://#diff-184ca5fd1c3cd0a167e9a328eb2ea765a5d1c319918b4bf28f2891e507cebb8cL89-R91): Added a foreign key constraint to the `ingredientSupplied` column in the `Supplier` table, referencing the `ingredientID` in the `Ingredient` table, with `ON DELETE CASCADE` and `ON UPDATE CASCADE` options to maintain referential integrity